### PR TITLE
Add commit-sha in version details, fix too large file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Build the main branch of react-client and deploy it
     steps:
+      - name: Install required moreutils
+        run: sudo apt-get install moreutils gzip -yqq
       - name: Checkout react-client repository
         uses: actions/checkout@v2
         with:
@@ -37,6 +39,16 @@ jobs:
         run: yarn install --frozen-lockfile --prefer-offline
       - name: Change URL of branding
         run: sed -i 's/http:\/\/localhost:3001\/img\/acme.png/\/img\/acme.png/' public/api/v2/config
+      - name: Get current commit hash
+        id: get-commit-hash
+        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      - name: Change version information
+        run: |
+          sed -i 's/0.0/dev-${{ steps.get-commit-hash.outputs.sha }}/' src/version.json
+          sed -i 's/www.youtube.com/watch?v=dQw4w9WgXcQ/github.com\/hedgedoc\/react-client\/tree\/${{ steps.get-commit-hash.outputs.sha }}/' src/version.json
+          jq ". |= del(.version.sourceCodeUrl, .version.issueTrackerUrl)" public/api/v2/config | sponge public/api/v2/config
+      - name: Update banner
+        run: sed -i 's/the test banner text/a ui-demo instance without backend for commit ${{ steps.get-commit-hash.outputs.sha }}/' public/api/v2/notes/banner
       - name: Create cname file
         run: echo -e "ui-test.hedgedoc.org\nui-test.hedgedoc.net\n" > public/CNAME
       - name: Build project
@@ -44,6 +56,8 @@ jobs:
       - name: Fix 404 problem
         run: ln -s index.html 404.html
         working-directory: build
+      - name: Compress stats.json
+        run: gzip build/stats.json
       - name: Deploy to GitHub Pages Branch
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
This PR replaces the config and version file parts for version information with the current git commit short-ref. Additionally the too large file error should be fixed with this by compressing it.