### PR TITLE
Fix mock API route to /private instead of /v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
       
       - name: Change branding url
-        run: jq '.branding.logo = "/img/demo.png"' public/api/v2/config | sponge public/api/v2/config
+        run: jq '.branding.logo = "/img/demo.png"' public/api/private/config | sponge public/api/private/config
       - name: Write commit hash into version file
         run: jq '.version = "dev-${{ steps.get-commit-hash.outputs.sha }}"' src/version.json | sponge src/version.json
       - name: Correct source code url
@@ -55,11 +55,11 @@ jobs:
       - name: Correct issue tracker url
         run: jq '.issueTrackerUrl = "https://github.com/hedgedoc/react-client/issues"' src/version.json | sponge src/version.json
       - name: Correct iframe communication origins
-        run: jq '.iframeCommunication |= map_values("https://ui-test.hedgedoc.org")' public/api/v2/config | sponge public/api/v2/config
+        run: jq '.iframeCommunication |= map_values("https://ui-test.hedgedoc.org")' public/api/private/config | sponge public/api/private/config
       - name: Remove backend github URLs
-        run: jq '. |= del(.version.sourceCodeUrl, .version.issueTrackerUrl)' public/api/v2/config | sponge public/api/v2/config
+        run: jq '. |= del(.version.sourceCodeUrl, .version.issueTrackerUrl)' public/api/private/config | sponge public/api/private/config
       - name: Update banner text
-        run: jq '.banner.text = "ui-demo instance without backend for commit ${{ steps.get-commit-hash.outputs.sha }}"' public/api/v2/config | sponge public/api/v2/config
+        run: jq '.banner.text = "ui-demo instance without backend for commit ${{ steps.get-commit-hash.outputs.sha }}"' public/api/private/config | sponge public/api/private/config
       
       - name: Create cname file
         run: echo -e "ui-test.hedgedoc.org\nui-test.hedgedoc.net\n" > public/CNAME


### PR DESCRIPTION
In hedgedoc/react-client#1189 the API route was changed from /api/v2/ to /api/private/. This updates the ui-test to use the same route in the mocked config files.

Fixes #3 